### PR TITLE
Usunięte zduplikowane pozycje oferty w ofertach

### DIFF
--- a/src/main/java/wh/plus/crm/controller/LeadController.java
+++ b/src/main/java/wh/plus/crm/controller/LeadController.java
@@ -5,6 +5,8 @@ import org.springframework.data.domain.Page;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.data.web.PagedResourcesAssembler;
 import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.hateoas.EntityModel;
@@ -37,7 +39,7 @@ public class LeadController {
 
     @GetMapping
     public ResponseEntity<PagedModel<EntityModel<LeadDTO>>> findAll(
-            Pageable pageable,
+            @PageableDefault(sort = "id", direction = Sort.Direction.DESC) Pageable pageable,
             @RequestParam(required = false) @DateTimeFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss") LocalDateTime fromDate,
             @RequestParam(required = false) @DateTimeFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss") LocalDateTime toDate,
             @RequestParam(required = false) String employee,
@@ -49,6 +51,7 @@ public class LeadController {
         PagedModel<EntityModel<LeadDTO>> pagedModel = assembler.toModel(leads);
         return new ResponseEntity<>(pagedModel, HttpStatus.OK);
     }
+
 
     @GetMapping("/{id}")
     public ResponseEntity<LeadDTO> getLeadById(@PathVariable Long id) {

--- a/src/main/java/wh/plus/crm/controller/OfferController.java
+++ b/src/main/java/wh/plus/crm/controller/OfferController.java
@@ -56,6 +56,7 @@ public class OfferController {
             @RequestParam(required = false) Long projectId,
             @RequestParam(required = false) Long leadId,
             @RequestParam(required = false) Long clientId,
+            @RequestParam(required = false) Long salesTeamId, // Dodany parametr
             @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime startDate,
             @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime endDate,
             @RequestParam(required = false) SalesOpportunityLevel salesOpportunityLevel,
@@ -64,15 +65,15 @@ public class OfferController {
     ) {
 
         Page<OfferDTO> offers = offerService.searchOffers(
-                 createdBy,  name,  clientType,  investorType,  offerStatus,  objectType,  description,  userId,  clientId,  leadId,  projectId,
-                 startDate,  endDate,  salesOpportunityLevel, pageable
+                createdBy, name, clientType, investorType, offerStatus, objectType, description,
+                userId, clientId, leadId, projectId, salesTeamId, startDate, endDate, salesOpportunityLevel, pageable
         );
 
-        // Tworzenie modelu HATEOAS
         PagedModel<EntityModel<OfferDTO>> pagedModel = assembler.toModel(offers);
 
         return ResponseEntity.ok(pagedModel);
     }
+
 
 
 

--- a/src/main/java/wh/plus/crm/controller/SalesTeamController.java
+++ b/src/main/java/wh/plus/crm/controller/SalesTeamController.java
@@ -1,0 +1,26 @@
+package wh.plus.crm.controller;
+
+import lombok.AllArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import wh.plus.crm.model.user.SalesTeam;
+import wh.plus.crm.service.SalesTeamService;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/sales-team")
+@AllArgsConstructor
+public class SalesTeamController {
+
+    private final SalesTeamService salesTeamService;
+
+    @GetMapping
+    public ResponseEntity<List<SalesTeam>> getAllSalesTeams() {
+        return ResponseEntity.ok(salesTeamService.getAllSalesTeams());
+    }
+
+
+}

--- a/src/main/java/wh/plus/crm/dto/lead/LeadDTO.java
+++ b/src/main/java/wh/plus/crm/dto/lead/LeadDTO.java
@@ -8,6 +8,7 @@ import wh.plus.crm.model.user.User;
 import wh.plus.crm.model.RejectionReason;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 @Data
 @AllArgsConstructor
@@ -20,7 +21,7 @@ public class LeadDTO {
 
     private String clientGlobalId;
     private boolean isFinal;
-    private OfferSummaryDTO offer;
+    private List<OfferSummaryDTO> offers;
 
     private RejectionReason rejectionReason;
     private String rejectionReasonComment;

--- a/src/main/java/wh/plus/crm/dto/offer/OfferDTO.java
+++ b/src/main/java/wh/plus/crm/dto/offer/OfferDTO.java
@@ -40,7 +40,8 @@ public class OfferDTO {
     private BigDecimal totalPrice;
 
 
-
+    private Long salesTeamId;
+    private String salesTeamName;
 
     private LocalDateTime rejectionOrApprovalDate;
     private LocalDateTime signedContractDate;

--- a/src/main/java/wh/plus/crm/dto/offer/OfferSummaryDTO.java
+++ b/src/main/java/wh/plus/crm/dto/offer/OfferSummaryDTO.java
@@ -12,4 +12,5 @@ public class OfferSummaryDTO {
     private Long id;
     private String name;
     private OfferStatus offerStatus;
+
 }

--- a/src/main/java/wh/plus/crm/mapper/LeadMapper.java
+++ b/src/main/java/wh/plus/crm/mapper/LeadMapper.java
@@ -24,6 +24,7 @@ public interface LeadMapper {
     @Mapping(source = "clientGlobalId", target = "clientId")
     @Mapping(source = "leadStatus.id", target = "leadStatusId")
     @Mapping(source = "leadSource.id", target = "leadSourceId")
+    @Mapping(source = "offers", target = "offers")
     LeadDTO leadToLeadDTO(Lead lead);
 
     LeadSummaryDTO toLeadSummaryDTO(Lead lead);

--- a/src/main/java/wh/plus/crm/mapper/OfferMapper.java
+++ b/src/main/java/wh/plus/crm/mapper/OfferMapper.java
@@ -8,7 +8,7 @@ import wh.plus.crm.model.offer.OfferItem;
 
 import java.util.List;
 
-@Mapper(componentModel = "spring",uses = {UserMapper.class, ProjectMapper.class, LeadMapper.class, ClientMapper.class})
+@Mapper(componentModel = "spring",uses = {UserMapper.class, ProjectMapper.class, LeadMapper.class, ClientMapper.class, })
 public interface OfferMapper {
 
     @Mapping(target = "offerItemList", source = "offerItems")
@@ -18,6 +18,7 @@ public interface OfferMapper {
     @Mapping(target = "user", ignore = true)
     @Mapping(target = "euroExchangeRate", source = "euroExchangeRate") // Mapowanie kursu euro
     @Mapping(target = "clientGlobalId", source = "clientGlobalId")
+    @Mapping(target = "salesTeam.id", source = "salesTeamId")
     Offer toEntity(OfferDTO offerDTO);
 
     @Mapping(target = "offerItems", source = "offerItemList")
@@ -29,6 +30,8 @@ public interface OfferMapper {
     @Mapping(source = "clientGlobalId", target = "clientGlobalId")
     @Mapping(target = "rejectionOrApprovalDate", source = "rejectionOrApprovalDate")
     @Mapping(target = "signedContractDate", source = "signedContractDate")
+    @Mapping(target = "salesTeamId", source = "salesTeam.id")
+    @Mapping(target = "salesTeamName", source = "salesTeam.name")
     OfferDTO toOfferDTO(Offer offer);
 
     @Mapping(target = "offer", ignore = true)

--- a/src/main/java/wh/plus/crm/model/offer/Offer.java
+++ b/src/main/java/wh/plus/crm/model/offer/Offer.java
@@ -10,6 +10,7 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 import wh.plus.crm.model.Auditable;
 import wh.plus.crm.model.Currency;
 import wh.plus.crm.model.RejectionReason;
+import wh.plus.crm.model.user.SalesTeam;
 import wh.plus.crm.model.user.User;
 import wh.plus.crm.model.client.Client;
 import wh.plus.crm.model.lead.Lead;
@@ -29,7 +30,7 @@ import java.util.List;
 public class Offer extends Auditable<String> {
 
     @Id
-   @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     private String name;
@@ -85,6 +86,11 @@ public class Offer extends Auditable<String> {
 
     @Column(nullable = true)
     private LocalDateTime signedContractDate;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "sales_team_id", nullable = true)
+    @Audited(targetAuditMode = RelationTargetAuditMode.NOT_AUDITED)
+    private SalesTeam salesTeam;
 
 
     @ManyToOne(fetch = FetchType.LAZY)

--- a/src/main/java/wh/plus/crm/model/user/SalesTeam.java
+++ b/src/main/java/wh/plus/crm/model/user/SalesTeam.java
@@ -1,0 +1,29 @@
+package wh.plus.crm.model.user;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Entity
+@Table(name = "sales_teams")
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class SalesTeam {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private long id;
+
+    @Column(nullable = false, unique = true)
+    private String name;
+
+    @OneToMany(mappedBy = "team", cascade = CascadeType.PERSIST, orphanRemoval = true)
+    private List<User> users;
+
+
+
+}

--- a/src/main/java/wh/plus/crm/model/user/User.java
+++ b/src/main/java/wh/plus/crm/model/user/User.java
@@ -56,7 +56,6 @@ public class User implements UserDetails {
     }
 
 
-
     @Override
     public boolean isAccountNonExpired() {
         return true;
@@ -76,6 +75,10 @@ public class User implements UserDetails {
     public boolean isEnabled() {
         return true;
     }
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "team_id")
+    private SalesTeam team;
 
 
 

--- a/src/main/java/wh/plus/crm/repository/SalesTeamRepository.java
+++ b/src/main/java/wh/plus/crm/repository/SalesTeamRepository.java
@@ -1,0 +1,7 @@
+package wh.plus.crm.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import wh.plus.crm.model.user.SalesTeam;
+
+public interface SalesTeamRepository extends JpaRepository<SalesTeam, Long> {
+}

--- a/src/main/java/wh/plus/crm/service/OfferService.java
+++ b/src/main/java/wh/plus/crm/service/OfferService.java
@@ -15,6 +15,7 @@ import wh.plus.crm.dto.offer.OfferItemDTO;
 import wh.plus.crm.helper.NullPropertyUtils;
 import wh.plus.crm.mapper.OfferMapper;
 import wh.plus.crm.model.Currency;
+import wh.plus.crm.model.user.SalesTeam;
 import wh.plus.crm.model.user.User;
 import wh.plus.crm.model.client.Client;
 import wh.plus.crm.model.lead.Lead;
@@ -40,6 +41,7 @@ public class OfferService {
     private final LeadRepository leadRepository;
     private final ClientRepository clientRepository;
     private final ProjectRepository projectRepository;
+    private final SalesTeamRepository salesTeamRepository;
 
     public Page<OfferDTO> getOffers(Pageable pageable) {
 
@@ -62,7 +64,7 @@ public class OfferService {
     public Page<OfferDTO> searchOffers(
             String createdBy, String name, ClientType clientType, InvestorType investorType,
             OfferStatus offerStatus, ObjectType objectType, String description, Long userId,
-            Long clientId, Long leadId, Long projectId, LocalDateTime startDate,
+            Long clientId, Long leadId, Long projectId, Long salesTeamId, LocalDateTime startDate,
             LocalDateTime endDate, SalesOpportunityLevel salesOpportunityLevel, Pageable pageable) {
 
         Specification<Offer> specification = Specification.where(null);
@@ -99,6 +101,9 @@ public class OfferService {
         }
         if (projectId != null) {
             specification = specification.and(OfferSpecification.hasProject(projectId));
+        }
+        if (salesTeamId != null) {
+            specification = specification.and(OfferSpecification.hasSalesTeam(salesTeamId));
         }
         if (salesOpportunityLevel != null) {
             specification = specification.and(OfferSpecification.hasSalesOpportunityLevel(salesOpportunityLevel));
@@ -168,6 +173,12 @@ public class OfferService {
             Project project = projectRepository.findById(offerDTO.getProject().getId())
                     .orElseThrow(() -> new IllegalArgumentException("Project not found"));
             offer.setProject(project);
+        }
+
+        if (offerDTO.getSalesTeamId() != null) {
+            SalesTeam salesTeam = salesTeamRepository.findById(offerDTO.getSalesTeamId())
+                    .orElseThrow(() -> new IllegalArgumentException("Sales Team not found"));
+            offer.setSalesTeam(salesTeam);
         }
 
         // Ustawienie clientGlobalId

--- a/src/main/java/wh/plus/crm/service/SalesTeamService.java
+++ b/src/main/java/wh/plus/crm/service/SalesTeamService.java
@@ -1,0 +1,21 @@
+package wh.plus.crm.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import wh.plus.crm.model.user.SalesTeam;
+import wh.plus.crm.repository.SalesTeamRepository;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class SalesTeamService {
+
+    private final SalesTeamRepository salesTeamRepository;
+
+    public List<SalesTeam> getAllSalesTeams() {
+        return salesTeamRepository.findAll();
+    }
+
+
+}

--- a/src/main/java/wh/plus/crm/specyfications/OfferSpecification.java
+++ b/src/main/java/wh/plus/crm/specyfications/OfferSpecification.java
@@ -35,6 +35,10 @@ public class OfferSpecification {
         return (root, query, criteriaBuilder) -> criteriaBuilder.like(root.get("description"), "%" + description + "%");
     }
 
+    public static Specification<Offer> hasSalesTeam(Long salesTeamId) {
+        return (root, query, criteriaBuilder) -> criteriaBuilder.equal(root.get("salesTeam").get("id"), salesTeamId);
+    }
+
     public static Specification<Offer> hasUser(Long userId) {
         return (root, query, criteriaBuilder) ->
                 criteriaBuilder.equal(root.get("user").get("id"), userId);

--- a/src/main/resources/application-dev.properties
+++ b/src/main/resources/application-dev.properties
@@ -20,10 +20,10 @@ spring.flyway.baseline-on-migrate=true
 
 # Konfiguracja logowania
 logging.level.org.flywaydb=ERROR
-logging.level.org.springframework=ERROR
-logging.level.org.hibernate=ERROR
-logging.level.org.hibernate.SQL=ERROR
-logging.level.org.hibernate.type.descriptor.sql=ERROR
+logging.level.org.springframework=INFO
+logging.level.org.hibernate=INFO
+logging.level.org.hibernate.SQL=INFO
+logging.level.org.hibernate.type.descriptor.sql=INFO
 spring.jpa.show-sql=false
 spring.jpa.properties.hibernate.format_sql=true
 

--- a/src/main/resources/db/migration/V1__insert_users.sql
+++ b/src/main/resources/db/migration/V1__insert_users.sql
@@ -1,0 +1,13 @@
+INSERT INTO users (id, username, password, email, fullname, avatar, phone, is_sales_representative)
+VALUES
+    (2, 'jagodaszymczak', '$2a$08$AYYWo0zOAgDCTnnfz2Oxa.CfK3QZTw4CUm25i8/tPG/OLS.4/aQIm', 'jagoda@w-h.pl', 'Jagoda Szymczak', 'https://wyposazenie-hotelowe.pl/wp-content/uploads/2023/07/jagoda-500x500.png', 539631014, 1),
+    (3, 'piotrswitalski', '$2a$08$9P78p0g8.FAnYY79kaQcseitbm3dvqamM4/YM7BZIP.0IewIOPhB.', 'piotr@w-h.pl', 'Piotr Świtalski', 'piotr.png', 506332373, 0),
+    (5, 'justynachociaj', '$2a$08$Vde2.y4ivqzQ6RpqTVGOdOfROUVVxtKtEWLu47oPdouKGNYWAco/a', 'justyna@w-h.pl', 'Justyna Chociaj', NULL, NULL,0),
+    (6, 'dorotaprzybyla', '$2a$08$pXFuLvx8HOhFCGQeKyq.YulZPfgKbMI3EOLX4MeJsp5t5br1sLJiu', 'dorota@w-h.pl', 'Dorota Przybyła', 'dorota.png', NULL,0),
+    (7, 'dariuszkwiecinski', '$2a$08$AdnZO/Mqulsq6wyPZi7X4uf.Mm84I7FhyvH7dAy3Z30rBCSVEUp9C', 'dkwiecinski@w-h.pl', 'Dariusz Kwieciński', 'https://wyposazenie-hotelowe.pl/wp-content/uploads/2023/07/darek-500x500.png', NULL,1),
+    (8, 'grzegorzraczek', '$2a$08$lMg1Lu6IcSxajWoHXLJbUO8CqzPy.SqUoLz6V/TTMFkvNbAtu7U6u', 'g.raczek@w-h.pl', 'Grzegorz Raczek', 'https://wyposazenie-hotelowe.pl/wp-content/uploads/2023/07/grzegorz-1-500x500.png', NULL,1),
+    (9, 'krystiankwiecinski', '$2a$08$dYmzJ5ciocH0THpic5uzkejWNfHoyP0dFodJqhmGQ5Uy0rNipwe06', 'krystian@w-h.pl', 'Krystian Kwieciński', 'https://wyposazenie-hotelowe.pl/wp-content/uploads/2023/12/krystian-500x500.jpeg', NULL,1),
+    (10, 'joannaapryjas', '$2a$08$/WEXjGx3Y.SyS1DgI/f1deQlJPEJxm7nJ27/hfrMEPjciUOOXSJ8G', 'joanna@w-h.pl', 'Joanna Apryjas', 'https://wyposazenie-hotelowe.pl/wp-content/uploads/2023/07/joanna-1-500x500.png', NULL,1),
+    (12, 'rafalhyla', '$2a$08$Gdo0mTrC4rU1fduyggEvpe1zg9I.a09PjB5rv6eQmeK5JP02KOfEK', 'info@rafalhyla.pl', 'Rafał Hyla', 'https://wyposazenie-hotelowe.pl/wp-content/uploads/2023/12/rafal-500x500.jpeg', NULL,1),
+    (16, 'agatagryszka', '$2a$08$0J2KcebPmZWVP2pFzSGiPO06vU23Vz3asNsfYXUhNtJiD9T2p3.pC', 'agata@bogu.pl', 'Agata Gryszka', NULL, NULL, 0),
+    (20, 'agnieszkakawa', '$2a$08$AJEySlgFdAjqCbe82ORWLu8cIfJvuJpyttAvhtEiMWJX5lFDMbhvm', 'agnieszka.kawa@w-h.pl', 'Agnieszka Kawa', NULL, NULL,0);

--- a/src/main/resources/db/migration/V2__insert_users.sql
+++ b/src/main/resources/db/migration/V2__insert_users.sql
@@ -1,0 +1,13 @@
+INSERT INTO users (id, username, password, email, fullname, avatar, phone, is_sales_representative)
+VALUES
+    (2, 'jagodaszymczak', '$2a$08$AYYWo0zOAgDCTnnfz2Oxa.CfK3QZTw4CUm25i8/tPG/OLS.4/aQIm', 'jagoda@w-h.pl', 'Jagoda Szymczak', 'https://wyposazenie-hotelowe.pl/wp-content/uploads/2023/07/jagoda-500x500.png', 539631014, 1),
+    (3, 'piotrswitalski', '$2a$08$9P78p0g8.FAnYY79kaQcseitbm3dvqamM4/YM7BZIP.0IewIOPhB.', 'piotr@w-h.pl', 'Piotr Świtalski', 'piotr.png', 506332373, 0),
+    (5, 'justynachociaj', '$2a$08$Vde2.y4ivqzQ6RpqTVGOdOfROUVVxtKtEWLu47oPdouKGNYWAco/a', 'justyna@w-h.pl', 'Justyna Chociaj', NULL, NULL,0),
+    (6, 'dorotaprzybyla', '$2a$08$pXFuLvx8HOhFCGQeKyq.YulZPfgKbMI3EOLX4MeJsp5t5br1sLJiu', 'dorota@w-h.pl', 'Dorota Przybyła', 'dorota.png', NULL,0),
+    (7, 'dariuszkwiecinski', '$2a$08$AdnZO/Mqulsq6wyPZi7X4uf.Mm84I7FhyvH7dAy3Z30rBCSVEUp9C', 'dkwiecinski@w-h.pl', 'Dariusz Kwieciński', 'https://wyposazenie-hotelowe.pl/wp-content/uploads/2023/07/darek-500x500.png', NULL,1),
+    (8, 'grzegorzraczek', '$2a$08$lMg1Lu6IcSxajWoHXLJbUO8CqzPy.SqUoLz6V/TTMFkvNbAtu7U6u', 'g.raczek@w-h.pl', 'Grzegorz Raczek', 'https://wyposazenie-hotelowe.pl/wp-content/uploads/2023/07/grzegorz-1-500x500.png', NULL,1),
+    (9, 'krystiankwiecinski', '$2a$08$dYmzJ5ciocH0THpic5uzkejWNfHoyP0dFodJqhmGQ5Uy0rNipwe06', 'krystian@w-h.pl', 'Krystian Kwieciński', 'https://wyposazenie-hotelowe.pl/wp-content/uploads/2023/12/krystian-500x500.jpeg', NULL,1),
+    (10, 'joannaapryjas', '$2a$08$/WEXjGx3Y.SyS1DgI/f1deQlJPEJxm7nJ27/hfrMEPjciUOOXSJ8G', 'joanna@w-h.pl', 'Joanna Apryjas', 'https://wyposazenie-hotelowe.pl/wp-content/uploads/2023/07/joanna-1-500x500.png', NULL,1),
+    (12, 'rafalhyla', '$2a$08$Gdo0mTrC4rU1fduyggEvpe1zg9I.a09PjB5rv6eQmeK5JP02KOfEK', 'info@rafalhyla.pl', 'Rafał Hyla', 'https://wyposazenie-hotelowe.pl/wp-content/uploads/2023/12/rafal-500x500.jpeg', NULL,1),
+    (16, 'agatagryszka', '$2a$08$0J2KcebPmZWVP2pFzSGiPO06vU23Vz3asNsfYXUhNtJiD9T2p3.pC', 'agata@bogu.pl', 'Agata Gryszka', NULL, NULL, 0),
+    (20, 'agnieszkakawa', '$2a$08$AJEySlgFdAjqCbe82ORWLu8cIfJvuJpyttAvhtEiMWJX5lFDMbhvm', 'agnieszka.kawa@w-h.pl', 'Agnieszka Kawa', NULL, NULL,0);

--- a/src/main/resources/db/migration/V4__Add_sales_teams.sql
+++ b/src/main/resources/db/migration/V4__Add_sales_teams.sql
@@ -1,0 +1,14 @@
+-- Tworzenie tabeli sales_teams
+CREATE TABLE sales_teams (
+                             id BIGINT AUTO_INCREMENT PRIMARY KEY,
+                             name VARCHAR(255) NOT NULL UNIQUE
+);
+
+-- Dodanie kolumny sales_team_id do tabeli users
+ALTER TABLE users ADD COLUMN sales_team_id BIGINT;
+
+-- Dodanie klucza obcego pomiędzy users a sales_teams
+ALTER TABLE users ADD CONSTRAINT fk_sales_team_user FOREIGN KEY (sales_team_id) REFERENCES sales_teams(id);
+
+-- Dodanie przykładowych teamów sprzedażowych
+INSERT INTO sales_teams (name) VALUES ('Team A'), ('Team B'), ('Team C');

--- a/src/main/resources/db/migration/V5__Add_sales_teams_to_offer.sql
+++ b/src/main/resources/db/migration/V5__Add_sales_teams_to_offer.sql
@@ -1,0 +1,4 @@
+ALTER TABLE offers ADD COLUMN sales_team_id BIGINT;
+
+-- Dodanie klucza obcego do tabeli sales_teams
+ALTER TABLE offers ADD CONSTRAINT fk_sales_team_offer FOREIGN KEY (sales_team_id) REFERENCES sales_teams(id);


### PR DESCRIPTION
Dodana obsługa teamów - daje to większe możlwiosći analityczne. Przy dodawaniu oferty wyberamy handlowaca oraz team. Dodane filtrowanie ofert po teamach.
W celu optymalizacji kosztów i ilości zapytań filtry w ofertach należy wykonac przez kliknięcie przycisku filtruj Dodany mechanizm, który zapamiętuje wybrane filtry - działa to nawet po zamknieciu przeglądarki Dodany licznik elementów na stronie pod nawigacją
Naprawiona kolejność wyświetlanych leadów po użyciu filtrowania Przywrócone wyswietlanie statusów ofert na liście leadów Dodanie informcji o powiązanym obiekcie na stronie konkretnej oferty